### PR TITLE
fix(Widgets): add unit test for namespaced widgets

### DIFF
--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -160,7 +160,13 @@ class WP_Widget {
 	 *                                information on accepted arguments. Default empty array.
 	 */
 	public function __construct( $id_base, $name, $widget_options = array(), $control_options = array() ) {
-		$this->id_base         = empty( $id_base ) ? preg_replace( '/(wp_)?widget_/', '', strtolower( get_class( $this ) ) ) : strtolower( $id_base );
+		if ( empty( $id_base ) ) {
+			$id_base = explode( '\\', preg_replace( '/(wp_)?widget_/', '', strtolower( get_class( $this ) ) ) );
+			$id_base = end( $id_base );
+		} else {
+			$id_base = strtolower( $id_base );
+		}
+		$this->id_base         = $id_base;
 		$this->name            = $name;
 		$this->option_name     = 'widget_' . $this->id_base;
 		$this->widget_options  = wp_parse_args(

--- a/tests/phpunit/tests/widgets-namespaced.php
+++ b/tests/phpunit/tests/widgets-namespaced.php
@@ -1,0 +1,51 @@
+<?php
+// An example test namespaced widget
+namespace TestSpace\Sub\Sub {
+	class Testwidget extends \WP_Widget {
+		function __construct() {
+			// An empty first argument is passed to use the default id_base calculation
+			parent::__construct( '', 'unit-test-widget' );
+		}
+	}
+}
+
+namespace {
+	// A non-namespaced widget to ensure previous behavior still works
+	class Testwidget2 extends \WP_Widget {
+		function __construct() {
+			parent::__construct( '', 'unit-test-widget' );
+		}
+	}
+
+	/**
+	 * Test functions and classes for namespaced widgets.
+	 *
+	 * @group widgets
+	 */
+	class Tests_Widgets_Namespaced extends WP_UnitTestCase {
+
+		function clean_up_global_scope() {
+			global $wp_widget_factory;
+			$wp_widget_factory->widgets = array();
+			parent::clean_up_global_scope();
+		}
+
+		/**
+		 * @ticket 44098
+		 */
+		public function test_widget_with_namespace_without_id_base() {
+			global $wp_widget_factory;
+			register_widget( 'TestSpace\Sub\Sub\Testwidget' );
+			$this->assertEquals( 'testwidget', $wp_widget_factory->widgets['TestSpace\Sub\Sub\Testwidget']->id_base );
+		}
+
+		/**
+		 * @ticket 44098
+		 */
+		public function test_widget_without_namespace_without_id_base() {
+			global $wp_widget_factory;
+			register_widget( 'Testwidget2' );
+			$this->assertEquals( 'testwidget2', $wp_widget_factory->widgets['Testwidget2']->id_base );
+		}
+	}
+}


### PR DESCRIPTION
Adds a unit test for the base_id calculation on a namespaced widget.
Includes a non-namespaced widget to ensure functionality still works as
expected.

Trac #44098<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
Adds a unit test for the base_id calculation on a namespaced widget.
Includes a non-namespaced widget to ensure functionality still works as
expected.

Trac #44098