### PR TITLE
Fix tests & style in Mte90 patch1: 44098: Widget initialized without id_base with namespace

### DIFF
--- a/tests/phpunit/tests/widgets-namespaced.php
+++ b/tests/phpunit/tests/widgets-namespaced.php
@@ -1,22 +1,5 @@
 <?php
-// An example test namespaced widget
-namespace TestSpace\Sub\Sub {
-	class Testwidget extends \WP_Widget {
-		function __construct() {
-			// An empty first argument is passed to use the default id_base calculation
-			parent::__construct( '', 'unit-test-widget' );
-		}
-	}
-}
-
 namespace {
-	// A non-namespaced widget to ensure previous behavior still works
-	class Testwidget2 extends \WP_Widget {
-		function __construct() {
-			parent::__construct( '', 'unit-test-widget' );
-		}
-	}
-
 	/**
 	 * Test functions and classes for namespaced widgets.
 	 *
@@ -46,6 +29,23 @@ namespace {
 			global $wp_widget_factory;
 			register_widget( 'Testwidget2' );
 			$this->assertEquals( 'testwidget2', $wp_widget_factory->widgets['Testwidget2']->id_base );
+		}
+	}
+
+	// A non-namespaced widget to ensure previous behavior still works
+	class Testwidget2 extends \WP_Widget {
+		function __construct() {
+			parent::__construct( '', 'unit-test-widget' );
+		}
+	}
+}
+
+// An example test namespaced widget
+namespace TestSpace\Sub\Sub {
+	class Testwidget extends \WP_Widget {
+		function __construct() {
+			// An empty first argument is passed to use the default id_base calculation
+			parent::__construct( '', 'unit-test-widget' );
 		}
 	}
 }

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -1217,13 +1217,4 @@ class Tests_Widgets extends WP_UnitTestCase {
 		);
 		$this->assertEquals( $expected_sidebars, $new_next_theme_sidebars );
 	}
-
-	/**
-	 * @ticket 44098
-	 */
-	public function test_widget_with_namespace_without_id_base() {
-		global $wp_widget_factory, $wp_registered_widgets;
-		register_widget( 'Namespace\Sub\Sub\Class' );
-		$this->assertEquals( 'Class', $wp_widget_factory->widgets[0]->id_base );
-	}
 }


### PR DESCRIPTION
Removes test migrated into new file.

Fixes coding standards check by placing the unit test class first and the sample widget classes afterwards.